### PR TITLE
Goose移行の修正 & Environment secrets対応

### DIFF
--- a/.github/workflows/ci-develop.yml
+++ b/.github/workflows/ci-develop.yml
@@ -24,6 +24,7 @@ jobs:
   backend-db-migrate:
     name: backend / db migrate (goose)
     runs-on: ubuntu-latest
+    environment: develop
     defaults:
       run:
         working-directory: apps/backend
@@ -63,6 +64,7 @@ jobs:
     name: backend / deploy (Cloud Run develop)
     needs: backend-db-migrate
     runs-on: ubuntu-latest
+    environment: develop
     permissions:
       contents: "read"
       id-token: "write"
@@ -93,8 +95,9 @@ jobs:
 
   # frontend-deploy は Next.js アプリケーションを Cloudflare Pages/Workers にデプロイするジョブ
   frontend-deploy:
-    name: frontend / deploy (Cloudflare)
+    name: frontend / deploy (Cloudflare develop)
     runs-on: ubuntu-latest
+    environment: develop
     defaults:
       run:
         working-directory: apps/frontend

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -19,6 +19,7 @@ jobs:
   backend-db-migrate:
     name: backend / db migrate (goose)
     runs-on: ubuntu-latest
+    environment: production
     defaults:
       run:
         working-directory: apps/backend
@@ -36,7 +37,7 @@ jobs:
 
       - name: Run migration
         env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL_PROD }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: go run ./src/cmd/migrate up
 
   # backend-deploy は Go API を Cloud Run 本番環境にデプロイするジョブ
@@ -44,6 +45,7 @@ jobs:
     name: backend / deploy (Cloud Run production)
     needs: backend-db-migrate
     runs-on: ubuntu-latest
+    environment: production
     permissions:
       contents: "read"
       id-token: "write"
@@ -67,7 +69,7 @@ jobs:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           region: ${{ secrets.GCP_REGION }}
           env_vars: |
-            DATABASE_URL=${{ secrets.DATABASE_URL_PROD }}
+            DATABASE_URL=${{ secrets.DATABASE_URL }}
             CLERK_JWKS_URL=${{ secrets.CLERK_JWKS_URL }}
             TMDB_API_KEY=${{ secrets.TMDB_API_KEY }}
             ENV=production
@@ -76,6 +78,7 @@ jobs:
   frontend-deploy:
     name: frontend / deploy (Cloudflare production)
     runs-on: ubuntu-latest
+    environment: production
     defaults:
       run:
         working-directory: apps/frontend


### PR DESCRIPTION
## Summary
- Goose provider に渡す `embed.FS` を `fs.Sub` で補正し、CI上の `no migrations found` エラーを修正
- GitHub Environment secrets (`develop` / `production`) に対応し、環境ごとのシークレット管理を統一
- `DATABASE_URL_PROD` → `DATABASE_URL` に統一（Environment secrets で値を切り替え）

## Test plan
- [ ] CI の `backend-migration-check` ジョブ（up/down/up）が通ること
- [ ] develop push 時に `environment: develop` のシークレットが正しく注入されること
- [ ] main push 時に `environment: production` のシークレットが正しく注入されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)