### PR TITLE
✨ トップページに「今週のタグ」Top5 セクションを追加 (T-2026-0001)

### DIFF
--- a/apps/backend/src/internal/handler/tag_handler.go
+++ b/apps/backend/src/internal/handler/tag_handler.go
@@ -207,6 +207,45 @@ func (h *TagHandler) ListPublicTags(c *gin.Context) {
 	})
 }
 
+// @Summary 今週のトレンドタグを取得
+// @Description 直近 N 日間で映画追加・フォロー・いいねの合計件数が多い公開タグ上位を返す。スコア0のタグは含まれない。
+// @Tags tags
+// @Accept json
+// @Produce json
+// @Param period query string false "現状 'week' のみ。デフォルト 'week'（直近7日）"
+// @Param limit query int false "取得件数（1〜50、デフォルト 5）"
+// @Success 200 {object}
+// @Failure 500 {object}
+// @Router /api/v1/tags/trending [get]
+func (h *TagHandler) ListTrendingTags(c *gin.Context) {
+	period := c.Query("period")
+	days := 7
+	if period != "" && period != "week" {
+		// 将来の拡張用。未知の period は week 扱い（明示的にエラーにはしない）。
+		days = 7
+	}
+
+	limit := parseIntDefault(c.Query("limit"), 5)
+	if limit < 1 {
+		limit = 1
+	}
+	if limit > 50 {
+		limit = 50
+	}
+
+	items, err := h.tagService.ListTrendingTags(c.Request.Context(), days, limit)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to list trending tags"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"items":  items,
+		"period": "week",
+		"limit":  limit,
+	})
+}
+
 // @Summary タグを作成
 // @Description タグを作成
 // @Tags tags

--- a/apps/backend/src/internal/handler/tag_handler_test.go
+++ b/apps/backend/src/internal/handler/tag_handler_test.go
@@ -16,6 +16,7 @@ import (
 
 type fakeTagService struct {
 	ListPublicTagsFn     func(ctx context.Context, q, sort string, page, pageSize int) ([]service.TagListItem, int64, error)
+	ListTrendingTagsFn   func(ctx context.Context, days, limit int) ([]service.TagListItem, error)
 	ListTagsByUserIDFn   func(ctx context.Context, userID string, publicOnly bool, page, pageSize int) ([]service.TagListItem, int64, error)
 	GetTagDetailFn       func(ctx context.Context, tagID string, viewerUserID *string) (*service.TagDetail, error)
 	ListTagMoviesFn      func(ctx context.Context, tagID string, viewerUserID *string, page, pageSize int) ([]service.TagMovieItem, int64, error)
@@ -46,6 +47,13 @@ func (f *fakeTagService) ListTagsByUserID(ctx context.Context, userID string, pu
 		return []service.TagListItem{}, 0, nil
 	}
 	return f.ListTagsByUserIDFn(ctx, userID, publicOnly, page, pageSize)
+}
+
+func (f *fakeTagService) ListTrendingTags(ctx context.Context, days, limit int) ([]service.TagListItem, error) {
+	if f.ListTrendingTagsFn == nil {
+		return []service.TagListItem{}, nil
+	}
+	return f.ListTrendingTagsFn(ctx, days, limit)
 }
 
 func (f *fakeTagService) GetTagDetail(ctx context.Context, tagID string, viewerUserID *string) (*service.TagDetail, error) {
@@ -163,6 +171,7 @@ func newTagHandlerRouter(t *testing.T, tagSvc service.TagService, user *model.Us
 
 	api := r.Group("/api/v1")
 	api.GET("/tags", h.ListPublicTags)
+	api.GET("/tags/trending", h.ListTrendingTags)
 
 	// Optional Auth (認証なしでもアクセス可能)
 	optionalAuth := api.Group("/")
@@ -674,6 +683,65 @@ func TestTagHandler_ListPublicTags(t *testing.T) {
 		}
 		r := newTagHandlerRouter(t, svc, nil)
 		rw := testutil.PerformRequest(r, http.MethodGet, "/api/v1/tags", nil, nil)
+		if rw.Code != http.StatusInternalServerError {
+			t.Fatalf("expected 500, got %d", rw.Code)
+		}
+	})
+}
+
+func TestTagHandler_ListTrendingTags(t *testing.T) {
+	t.Parallel()
+
+	t.Run("デフォルト(period未指定, limit=5)でサービスが呼ばれる: 200", func(t *testing.T) {
+		t.Parallel()
+
+		var gotDays, gotLimit int
+		svc := &fakeTagService{
+			ListTrendingTagsFn: func(ctx context.Context, days, limit int) ([]service.TagListItem, error) {
+				gotDays, gotLimit = days, limit
+				return []service.TagListItem{}, nil
+			},
+		}
+		r := newTagHandlerRouter(t, svc, nil)
+		rw := testutil.PerformRequest(r, http.MethodGet, "/api/v1/tags/trending", nil, nil)
+		if rw.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", rw.Code)
+		}
+		if gotDays != 7 || gotLimit != 5 {
+			t.Fatalf("expected (days=7, limit=5), got (%d, %d)", gotDays, gotLimit)
+		}
+	})
+
+	t.Run("limit が範囲外: 1〜50 にクランプ", func(t *testing.T) {
+		t.Parallel()
+
+		var gotLimit int
+		svc := &fakeTagService{
+			ListTrendingTagsFn: func(ctx context.Context, days, limit int) ([]service.TagListItem, error) {
+				gotLimit = limit
+				return []service.TagListItem{}, nil
+			},
+		}
+		r := newTagHandlerRouter(t, svc, nil)
+		rw := testutil.PerformRequest(r, http.MethodGet, "/api/v1/tags/trending?limit=999", nil, nil)
+		if rw.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", rw.Code)
+		}
+		if gotLimit != 50 {
+			t.Fatalf("expected limit=50 (clamped), got %d", gotLimit)
+		}
+	})
+
+	t.Run("サービスが失敗: 500", func(t *testing.T) {
+		t.Parallel()
+
+		svc := &fakeTagService{
+			ListTrendingTagsFn: func(ctx context.Context, days, limit int) ([]service.TagListItem, error) {
+				return nil, errors.New("boom")
+			},
+		}
+		r := newTagHandlerRouter(t, svc, nil)
+		rw := testutil.PerformRequest(r, http.MethodGet, "/api/v1/tags/trending", nil, nil)
 		if rw.Code != http.StatusInternalServerError {
 			t.Fatalf("expected 500, got %d", rw.Code)
 		}

--- a/apps/backend/src/internal/repository/repository_integration_test.go
+++ b/apps/backend/src/internal/repository/repository_integration_test.go
@@ -33,13 +33,13 @@ func openIntegrationDB(t *testing.T) *gorm.DB {
 		t.Fatalf("pgcrypto extension の有効化に失敗: %v", err)
 	}
 
-	if err := db.AutoMigrate(&model.User{}, &model.Tag{}, &model.TagMovie{}, &model.TagFollower{}); err != nil {
+	if err := db.AutoMigrate(&model.User{}, &model.Tag{}, &model.TagMovie{}, &model.TagFollower{}, &model.TagLike{}); err != nil {
 		t.Fatalf("AutoMigrate に失敗: %v", err)
 	}
 
 	// 各テストの独立性を担保するため、対象テーブルをクリーンにする。
 	// NOTE: integration テスト専用DBで実行すること（開発用DBでは実行しない）。
-	if err := db.Exec(`TRUNCATE TABLE tag_followers, tag_movies, tags, users RESTART IDENTITY CASCADE;`).Error; err != nil {
+	if err := db.Exec(`TRUNCATE TABLE tag_likes, tag_followers, tag_movies, tags, users RESTART IDENTITY CASCADE;`).Error; err != nil {
 		t.Fatalf("テスト用DBの初期化（TRUNCATE）に失敗: %v", err)
 	}
 
@@ -221,6 +221,90 @@ func TestTagRepository_ListPublicTags_FollowerCountDesc(t *testing.T) {
 	if rows[1].FollowerCount != 1 {
 		t.Fatalf("expected follower_count=1, got %d", rows[1].FollowerCount)
 	}
+}
+
+func TestTagRepository_ListTrendingTags_ScoreAndLimit(t *testing.T) {
+	db := openIntegrationDB(t)
+	tx := beginTx(t, db)
+
+	u1 := createUser(t, tx, "clerk_u1", "alice")
+	u2 := createUser(t, tx, "clerk_u2", "bob")
+
+	// 公開タグ A/B/C と非公開タグ D
+	tA := createTag(t, tx, u1.ID, "公開タグA", true)
+	tB := createTag(t, tx, u1.ID, "公開タグB", true)
+	tC := createTag(t, tx, u1.ID, "公開タグC", true) // アクティビティなし
+	tD := createTag(t, tx, u1.ID, "非公開タグD", false)
+
+	now := time.Now().UTC()
+	since := now.Add(-7 * 24 * time.Hour)
+
+	// since 以降のアクティビティ（=スコアに加算）
+	// A: tag_movies x2 + tag_followers x1 = 3
+	if err := tx.Create(&[]model.TagMovie{
+		{TagID: tA.ID, TmdbMovieID: 11, AddedByUser: u1.ID, CreatedAt: now.Add(-1 * 24 * time.Hour)},
+		{TagID: tA.ID, TmdbMovieID: 12, AddedByUser: u1.ID, CreatedAt: now.Add(-2 * 24 * time.Hour)},
+	}).Error; err != nil {
+		t.Fatalf("tag_movies INSERT 失敗: %v", err)
+	}
+	if err := tx.Create(&model.TagFollower{TagID: tA.ID, UserID: u2.ID, CreatedAt: now.Add(-1 * time.Hour)}).Error; err != nil {
+		t.Fatalf("tag_followers INSERT 失敗: %v", err)
+	}
+
+	// B: tag_likes x1 = 1
+	if err := tx.Create(&model.TagLike{TagID: tB.ID, UserID: u2.ID, CreatedAt: now.Add(-3 * 24 * time.Hour)}).Error; err != nil {
+		t.Fatalf("tag_likes INSERT 失敗: %v", err)
+	}
+
+	// since より前（集計対象外）
+	if err := tx.Create(&model.TagMovie{TagID: tB.ID, TmdbMovieID: 99, AddedByUser: u1.ID, CreatedAt: now.Add(-30 * 24 * time.Hour)}).Error; err != nil {
+		t.Fatalf("古い tag_movies INSERT 失敗: %v", err)
+	}
+
+	// 非公開タグはアクティビティがあっても除外される
+	if err := tx.Create(&model.TagMovie{TagID: tD.ID, TmdbMovieID: 21, AddedByUser: u1.ID, CreatedAt: now.Add(-1 * time.Hour)}).Error; err != nil {
+		t.Fatalf("非公開 tag_movies INSERT 失敗: %v", err)
+	}
+
+	repo := NewTagRepository(tx)
+	ctx := context.Background()
+
+	rows, err := repo.ListTrendingTags(ctx, TrendingTagFilter{Since: since, Limit: 5})
+	if err != nil {
+		t.Fatalf("ListTrendingTags に失敗: %v", err)
+	}
+
+	// スコア > 0 のタグだけ返る（C はスコア0、D は非公開なので除外）
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(rows))
+	}
+	// スコア順: A(3) > B(1)
+	if rows[0].ID != tA.ID || rows[1].ID != tB.ID {
+		t.Fatalf("expected order [A, B], got [%s, %s]", rows[0].ID, rows[1].ID)
+	}
+
+	// limit が小さい場合は件数で打ち切られる
+	rowsLimited, err := repo.ListTrendingTags(ctx, TrendingTagFilter{Since: since, Limit: 1})
+	if err != nil {
+		t.Fatalf("ListTrendingTags(limit=1) に失敗: %v", err)
+	}
+	if len(rowsLimited) != 1 {
+		t.Fatalf("expected 1 row with limit=1, got %d", len(rowsLimited))
+	}
+	if rowsLimited[0].ID != tA.ID {
+		t.Fatalf("expected top to be A, got %s", rowsLimited[0].ID)
+	}
+
+	// since が未来なら一切ヒットしない（5件未満でもエラーにならず空が返る）
+	rowsEmpty, err := repo.ListTrendingTags(ctx, TrendingTagFilter{Since: now.Add(time.Hour), Limit: 5})
+	if err != nil {
+		t.Fatalf("ListTrendingTags(future since) に失敗: %v", err)
+	}
+	if len(rowsEmpty) != 0 {
+		t.Fatalf("expected 0 rows for future since, got %d", len(rowsEmpty))
+	}
+
+	_ = tC // unused-ガード（Cは無アクティビティのためゼロ件確認の対比用）
 }
 
 func TestTagRepository_ListPublicTags_TitleSearch(t *testing.T) {

--- a/apps/backend/src/internal/repository/tag_repository.go
+++ b/apps/backend/src/internal/repository/tag_repository.go
@@ -62,6 +62,12 @@ type UserTagListFilter struct {
 	Limit         int
 }
 
+// トレンドタグ取得時のフィルタ条件を表す。
+type TrendingTagFilter struct {
+	Since time.Time // この日時以降のアクティビティを集計対象とする
+	Limit int
+}
+
 // タグに関する永続化処理を表すインターフェース。
 type TagRepository interface {
 	Create(ctx context.Context, tag *model.Tag) error
@@ -70,6 +76,7 @@ type TagRepository interface {
 	UpdateByID(ctx context.Context, id string, patch TagUpdatePatch) error
 	ListPublicTags(ctx context.Context, filter TagListFilter) ([]TagSummary, int64, error)
 	ListTagsByUserID(ctx context.Context, filter UserTagListFilter) ([]TagSummary, int64, error)
+	ListTrendingTags(ctx context.Context, filter TrendingTagFilter) ([]TagSummary, error)
 }
 
 type tagRepository struct {
@@ -210,6 +217,43 @@ func (r *tagRepository) ListPublicTags(ctx context.Context, filter TagListFilter
 	}
 
 	return rows, total, nil
+}
+
+// 直近の利用増加が多い公開タグを取得する。
+// スコアは「指定日時以降の tag_movies / tag_followers / tag_likes の追加件数の合計」。
+// スコア > 0 のタグのみを返し、降順にソートする。
+func (r *tagRepository) ListTrendingTags(ctx context.Context, filter TrendingTagFilter) ([]TagSummary, error) {
+	if filter.Limit <= 0 {
+		return []TagSummary{}, nil
+	}
+
+	scoreSubquery := `(
+		(SELECT COUNT(*) FROM tag_movies WHERE tag_id = t.id AND created_at >= ?) +
+		(SELECT COUNT(*) FROM tag_followers WHERE tag_id = t.id AND created_at >= ?) +
+		(SELECT COUNT(*) FROM tag_likes WHERE tag_id = t.id AND created_at >= ?)
+	)`
+
+	qb := r.db.WithContext(ctx).
+		Table((model.Tag{}).TableName()+" AS t").
+		Joins("JOIN "+(model.User{}).TableName()+" AS u ON u.id = t.user_id").
+		Where("t.is_public = ?", true).
+		Select(`t.id, t.title, t.description, t.cover_image_url, t.is_public,
+				(SELECT COUNT(*) FROM tag_movies WHERE tag_id = t.id) AS movie_count,
+				(SELECT COUNT(*) FROM tag_followers WHERE tag_id = t.id) AS follower_count,
+				(SELECT COUNT(*) FROM tag_likes WHERE tag_id = t.id) AS like_count,
+				t.created_at,
+				u.display_name AS author, u.display_id AS author_display_id,
+				`+scoreSubquery+` AS trending_score`,
+			filter.Since, filter.Since, filter.Since).
+		Where(scoreSubquery+" > 0", filter.Since, filter.Since, filter.Since).
+		Order("trending_score DESC, t.created_at DESC").
+		Limit(filter.Limit)
+
+	var rows []TagSummary
+	if err := qb.Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
 }
 
 // 指定ユーザーのタグ一覧を取得する。

--- a/apps/backend/src/internal/service/tag_service.go
+++ b/apps/backend/src/internal/service/tag_service.go
@@ -35,6 +35,10 @@ type TagService interface {
 	// 公開タグを検索・ソート・ページングして返す。
 	ListPublicTags(ctx context.Context, q, sort string, page, pageSize int) ([]TagListItem, int64, error)
 
+	// 直近 days 日間で利用増加（映画追加・フォロー・いいね）が多かった公開タグを返す。
+	// limit は最大件数。スコアが0のタグは含まれない（増加分が無いタグは表示しない）。
+	ListTrendingTags(ctx context.Context, days, limit int) ([]TagListItem, error)
+
 	// ユーザーIDに紐づくタグ一覧を返す。
 	// publicOnly が true の場合、公開タグのみを返す（他ユーザーのページ閲覧時）。
 	ListTagsByUserID(ctx context.Context, userID string, publicOnly bool, page, pageSize int) ([]TagListItem, int64, error)
@@ -809,6 +813,78 @@ func (s *tagService) ListPublicTags(ctx context.Context, q, sort string, page, p
 	}
 
 	return items, total, nil
+}
+
+// 直近 days 日間で利用が増加した公開タグ上位を返す。
+func (s *tagService) ListTrendingTags(ctx context.Context, days, limit int) ([]TagListItem, error) {
+	if days <= 0 {
+		days = 7
+	}
+	if limit <= 0 {
+		limit = 5
+	}
+	if limit > 50 {
+		limit = 50
+	}
+
+	since := time.Now().Add(-time.Duration(days) * 24 * time.Hour)
+
+	rows, err := s.tagRepo.ListTrendingTags(ctx, repository.TrendingTagFilter{
+		Since: since,
+		Limit: limit,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(rows) == 0 {
+		return []TagListItem{}, nil
+	}
+
+	imagesByTag := make(map[string][]string, len(rows))
+	if s.movieService != nil {
+		for _, r := range rows {
+			tagMovies, err := s.tagMovieRepo.ListRecentByTag(ctx, r.ID, 4)
+			if err != nil {
+				return nil, err
+			}
+			for _, tm := range tagMovies {
+				if len(imagesByTag[r.ID]) >= 4 {
+					break
+				}
+				cache, err := s.movieService.EnsureMovieCache(ctx, tm.TmdbMovieID)
+				if err != nil {
+					continue
+				}
+				if cache.PosterPath == nil || *cache.PosterPath == "" {
+					continue
+				}
+				poster := *cache.PosterPath
+				if s.imageBaseURL != "" {
+					poster = s.imageBaseURL + poster
+				}
+				imagesByTag[r.ID] = append(imagesByTag[r.ID], poster)
+			}
+		}
+	}
+
+	items := make([]TagListItem, 0, len(rows))
+	for _, r := range rows {
+		items = append(items, TagListItem{
+			ID:              r.ID,
+			Title:           r.Title,
+			Description:     r.Description,
+			Author:          r.Author,
+			AuthorDisplayID: r.AuthorDisplayID,
+			CoverImageURL:   r.CoverImageURL,
+			IsPublic:        r.IsPublic,
+			MovieCount:      r.MovieCount,
+			FollowerCount:   r.FollowerCount,
+			LikeCount:       r.LikeCount,
+			Images:          imagesByTag[r.ID],
+			CreatedAt:       r.CreatedAt,
+		})
+	}
+	return items, nil
 }
 
 // ユーザーIDに紐づくタグ一覧を返す。

--- a/apps/backend/src/internal/testutil/fakes_repository.go
+++ b/apps/backend/src/internal/testutil/fakes_repository.go
@@ -16,6 +16,7 @@ type FakeTagRepository struct {
 	UpdateByIDFn       func(ctx context.Context, id string, patch repository.TagUpdatePatch) error
 	ListPublicTagsFn   func(ctx context.Context, filter repository.TagListFilter) ([]repository.TagSummary, int64, error)
 	ListTagsByUserIDFn func(ctx context.Context, filter repository.UserTagListFilter) ([]repository.TagSummary, int64, error)
+	ListTrendingTagsFn func(ctx context.Context, filter repository.TrendingTagFilter) ([]repository.TagSummary, error)
 }
 
 func (f *FakeTagRepository) Create(ctx context.Context, tag *model.Tag) error {
@@ -58,6 +59,13 @@ func (f *FakeTagRepository) ListTagsByUserID(ctx context.Context, filter reposit
 		return []repository.TagSummary{}, 0, nil
 	}
 	return f.ListTagsByUserIDFn(ctx, filter)
+}
+
+func (f *FakeTagRepository) ListTrendingTags(ctx context.Context, filter repository.TrendingTagFilter) ([]repository.TagSummary, error) {
+	if f.ListTrendingTagsFn == nil {
+		return []repository.TagSummary{}, nil
+	}
+	return f.ListTrendingTagsFn(ctx, filter)
 }
 
 // FakeTagMovieRepository は repository.TagMovieRepository の手書き fake です。

--- a/apps/backend/src/router/router.go
+++ b/apps/backend/src/router/router.go
@@ -86,6 +86,7 @@ func setupRoutes(r *gin.Engine, deps *Dependencies) {
 func setupPublicRoutes(api *gin.RouterGroup, deps *Dependencies) {
 	// タグ（公開）
 	api.GET("/tags", deps.TagHandler.ListPublicTags)
+	api.GET("/tags/trending", deps.TagHandler.ListTrendingTags)
 	api.GET("/tags/:tagId", deps.OptionalAuthMiddleware, deps.TagHandler.GetTagDetail)
 	api.GET("/tags/:tagId/movies", deps.OptionalAuthMiddleware, deps.TagHandler.ListTagMovies)
 	api.GET("/tags/:tagId/followers", deps.TagHandler.ListTagFollowers)

--- a/apps/frontend/src/app/_components/WeeklyTags.tsx
+++ b/apps/frontend/src/app/_components/WeeklyTags.tsx
@@ -1,0 +1,88 @@
+import Image from "next/image";
+import Link from "next/link";
+import { Film, Flame, ArrowRight } from "lucide-react";
+import type { TagListItem } from "@/lib/validation/tag.api";
+
+const TMDB_IMAGE_BASE = "https://image.tmdb.org/t/p/w500";
+
+function toFullImageUrl(src: string): string {
+  return src.startsWith("http") ? src : `${TMDB_IMAGE_BASE}${src}`;
+}
+
+export function WeeklyTags({ items }: { items: TagListItem[] }) {
+  if (items.length === 0) {
+    // データが無い時はセクションごと非表示にして、レイアウトを崩さない。
+    return null;
+  }
+
+  return (
+    <section className="bg-white">
+      <div className="max-w-6xl mx-auto px-6 py-12 md:py-16">
+        <div className="flex items-end justify-between mb-6 md:mb-8">
+          <div>
+            <span className="inline-flex items-center gap-1.5 px-3 py-1 bg-orange-100 text-orange-700 text-xs font-bold rounded-full mb-3">
+              <Flame className="w-3.5 h-3.5" />
+              TRENDING
+            </span>
+            <h2 className="text-2xl md:text-3xl font-black tracking-tight text-gray-900">
+              今週のタグ
+            </h2>
+            <p className="mt-2 text-sm md:text-base text-gray-500">
+              直近1週間で利用が増えたタグ Top {items.length}
+            </p>
+          </div>
+          <Link
+            href="/tags"
+            className="hidden sm:inline-flex items-center gap-1 text-sm font-semibold text-gray-700 hover:text-gray-900 transition-colors"
+          >
+            すべて見る
+            <ArrowRight className="w-4 h-4" />
+          </Link>
+        </div>
+
+        <ol className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          {items.map((tag, index) => (
+            <li key={tag.id}>
+              <Link
+                href={`/tags/${tag.id}`}
+                className="group flex items-center gap-4 bg-white border border-gray-200 rounded-2xl px-4 py-3 hover:border-gray-400 hover:shadow-md transition-all"
+              >
+                <span className="flex-shrink-0 w-9 h-9 rounded-full bg-gradient-to-br from-amber-400 to-orange-500 flex items-center justify-center text-white text-base font-black shadow-sm">
+                  {index + 1}
+                </span>
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm md:text-base font-bold text-gray-900 truncate group-hover:text-orange-600 transition-colors">
+                    {tag.title}
+                  </p>
+                  <p className="mt-0.5 flex items-center gap-1 text-xs text-gray-500">
+                    <Film className="w-3.5 h-3.5" />
+                    {tag.movieCount}本
+                    <span className="mx-1.5">·</span>
+                    by {tag.author}
+                  </p>
+                </div>
+                <div className="hidden sm:flex -space-x-2 flex-shrink-0">
+                  {tag.images.slice(0, 3).map((src, i) => (
+                    <div
+                      key={i}
+                      className="relative w-8 h-12 rounded-md overflow-hidden shadow-sm border border-white"
+                    >
+                      <Image
+                        src={toFullImageUrl(src)}
+                        alt=""
+                        fill
+                        className="object-cover"
+                        sizes="32px"
+                      />
+                    </div>
+                  ))}
+                </div>
+                <ArrowRight className="w-4 h-4 text-gray-300 group-hover:text-orange-500 group-hover:translate-x-0.5 transition-all flex-shrink-0" />
+              </Link>
+            </li>
+          ))}
+        </ol>
+      </div>
+    </section>
+  );
+}

--- a/apps/frontend/src/app/page.tsx
+++ b/apps/frontend/src/app/page.tsx
@@ -2,7 +2,10 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { ArrowRight, Tag, Users, Search } from "lucide-react";
 import { listTags, type ListTagsResult } from "@/lib/api/tags/list";
+import { listTrendingTags } from "@/lib/api/tags/trending";
+import type { TagListItem } from "@/lib/validation/tag.api";
 import { TagCard, type MarqueeTag } from "./_components/TagCard";
+import { WeeklyTags } from "./_components/WeeklyTags";
 
 // --- カラーパレット（実データ用の循環色） ---
 
@@ -288,8 +291,21 @@ export const metadata: Metadata = {
   },
 };
 
+async function fetchWeeklyTags(): Promise<TagListItem[]> {
+  try {
+    const result = await listTrendingTags({ period: "week", limit: 5 });
+    return result.items;
+  } catch {
+    // 取得失敗時はセクションを非表示にする（既存レイアウトを崩さない）
+    return [];
+  }
+}
+
 export default async function LandingPage() {
-  const { row1, row2 } = await fetchMarqueeTags();
+  const [{ row1, row2 }, weeklyTags] = await Promise.all([
+    fetchMarqueeTags(),
+    fetchWeeklyTags(),
+  ]);
 
   return (
     <div className="min-h-screen bg-white">
@@ -391,6 +407,9 @@ export default async function LandingPage() {
           </div>
         </div>
       </section>
+
+      {/* Weekly Tags (今週のタグ Top5) */}
+      <WeeklyTags items={weeklyTags} />
 
       {/* Tag Marquee Section */}
       <section className="py-16 md:py-20 bg-white overflow-hidden">

--- a/apps/frontend/src/lib/api/tags/trending.ts
+++ b/apps/frontend/src/lib/api/tags/trending.ts
@@ -1,0 +1,51 @@
+import { TrendingTagsResponseSchema, type TagListItem } from "@/lib/validation/tag.api";
+import { getPublicApiBaseOrThrow, safeJson, toApiErrorMessage } from "@/lib/api/_shared/http";
+
+export type TrendingPeriod = "week";
+
+export type ListTrendingTagsParams = {
+  period?: TrendingPeriod;
+  limit?: number;
+};
+
+export type TrendingTagsResult = {
+  items: TagListItem[];
+  period: string;
+  limit: number;
+};
+
+/**
+ * 直近の利用増加（映画追加・フォロー・いいね）が多い公開タグ上位を取得する。
+ * - 増加分が無いタグは含まれず、件数が limit に満たない場合は存在分のみ返る。
+ */
+export async function listTrendingTags(
+  params?: ListTrendingTagsParams,
+): Promise<TrendingTagsResult> {
+  const base = getPublicApiBaseOrThrow();
+  const url = new URL(`${base}/api/v1/tags/trending`);
+
+  url.searchParams.set("period", params?.period ?? "week");
+  if (params?.limit) {
+    url.searchParams.set("limit", params.limit.toString());
+  }
+
+  const res = await fetch(url.toString(), { method: "GET" });
+  const body = await safeJson(res);
+
+  if (!res.ok) {
+    throw new Error(
+      toApiErrorMessage({
+        status: res.status,
+        body,
+        fallback: "今週のタグの取得に失敗しました",
+      }),
+    );
+  }
+
+  const parsed = TrendingTagsResponseSchema.safeParse(body);
+  if (!parsed.success) {
+    throw new Error("今週のタグレスポンスの形式が不正です。");
+  }
+
+  return parsed.data;
+}

--- a/apps/frontend/src/lib/validation/tag.api.ts
+++ b/apps/frontend/src/lib/validation/tag.api.ts
@@ -69,6 +69,25 @@ export const TagsListResponseSchema = z
 
 export type TagsListResponse = z.infer<typeof TagsListResponseSchema>;
 
+/**
+ * GET /api/v1/tags/trending のレスポンス
+ * - { items, period, limit } を期待。items のみ厳密に検証する。
+ */
+export const TrendingTagsResponseSchema = z
+    .object({
+        items: z.array(TagListItemSchema),
+        period: z.string().optional(),
+        limit: z.number().int().nonnegative().optional(),
+    })
+    .passthrough()
+    .transform((data) => ({
+        items: data.items,
+        period: data.period ?? "week",
+        limit: data.limit ?? data.items.length,
+    }));
+
+export type TrendingTagsResponse = z.infer<typeof TrendingTagsResponseSchema>;
+
 export const AddMoviePolicySchema = z.enum(["everyone", "owner_only"]);
 export type AddMoviePolicy = z.infer<typeof AddMoviePolicySchema>;
 


### PR DESCRIPTION
## 概要

トップページに「今週のタグ」セクションを追加し、直近1週間で利用が増加した公開タグ上位5件を表示してトレンドタグへの導線を強化しました。 (T-2026-0001)

## 集計ロジック

「利用増加」のスコアは以下3要素の **直近7日** の合計件数として定義しました:

- `tag_movies` の追加（タグへの映画追加）
- `tag_followers` の作成（タグのフォロー）
- `tag_likes` の作成（タグへのいいね）

スコア > 0 の公開タグのみを対象とし、降順にソートして上位 N 件を返します。

## 変更点

### バックエンド

- **新規エンドポイント**: `GET /api/v1/tags/trending?period=week&limit=5`
  - `period`: 現状 `week` のみ（拡張用）
  - `limit`: 1〜50（デフォルト 5、範囲外はクランプ）
- 公開タグのみ対象、非公開タグは除外
- `apps/backend/src/internal/repository/tag_repository.go` — `ListTrendingTags(filter)` 追加
- `apps/backend/src/internal/service/tag_service.go` — `ListTrendingTags(days, limit)` 追加
- `apps/backend/src/internal/handler/tag_handler.go` — ハンドラ追加 + Swagger アノテーション
- `apps/backend/src/router/router.go` — 静的パスを `:tagId` より先に登録
- ハンドラユニットテスト + リポジトリ統合テストを追加

### フロントエンド

- **`WeeklyTags` コンポーネント**: Hero と既存マーキーの間に配置
  - 順位バッジ・タグ名・本数・著者・ポスター3枚をリスト表示
  - 各行は `/tags/{tagId}` へのリンク
- `apps/frontend/src/lib/api/tags/trending.ts` — API クライアント新規
- `apps/frontend/src/lib/validation/tag.api.ts` — `TrendingTagsResponseSchema` 追加
- `apps/frontend/src/app/page.tsx` — 並列取得 + セクション挿入

## 受入条件への対応

- [x] トップページに「今週のタグ」見出しのセクションが表示される
- [x] 直近1週間で利用が増加したタグが最大5件表示される
- [x] 各タグ名がそのタグページへのリンクとして機能する
- [x] 5件未満でもエラーにならない（バックエンドはスコア>0のみ返す。0件時はセクション自体を非表示にしてレイアウトを崩さない）
- [x] 既存のトップページレイアウトが崩れない

## テスト

- [x] バックエンド: \`go build ./...\` / \`go test ./...\` / \`go vet -tags=integration ./...\` 通過
- [x] フロントエンド: \`npm run lint\` / \`npx tsc --noEmit\` 通過
- [ ] 統合テスト（postgres-test 起動して \`go test -tags=integration ./...\`）
- [ ] ローカルで実際のトップページに「今週のタグ」セクションが描画されること
- [ ] スコア0や 0件時にセクションが非表示になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)